### PR TITLE
Type error for startingAngle function callback parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -202,7 +202,7 @@ declare namespace FusionCharts {
         
         centerLabel(labelText: string, options?: {}): void;
 
-        startingAngle(angle?: number, relative?: boolean, callback?: (output) => void): any;
+        startingAngle(angle?: number, relative?: boolean, callback?: (output:number) => void): any;
 
         zoomOut(): void;
 


### PR DESCRIPTION
205:71 Parameter 'output' implicitly has an 'any' type.